### PR TITLE
fix namespace issue

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    if (project.android.hasProperty("namespace")) {
+        namespace 'com.crazecoder.openfile'
+    }
+
     compileSdkVersion 33
 
     defaultConfig {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: open_file_safe_plus
 description: A plug-in that can call native APP to open files with string result in flutter, support iOS(UTI) / android(intent) / PC(ffi) / web(dart:html)
-version: 0.0.4
+version: 0.0.5
 homepage: https://github.com/mdshadatrahman/open_file_plus
 
 dependencies:


### PR DESCRIPTION
Fix namespace issue on android 34 after [Deprecated imperative apply of Flutter's Gradle plugins](https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply)